### PR TITLE
Adding GCP Goat to CTF\Cloud-Focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you'd like to contribute, please see the [contribution guidelines](contributi
 *This is a list of CTF challenges that specifically focus on exploiting cloud services.*
 
 - [CONVEX](https://github.com/Azure/CONVEX) - An open-source CTF platform that lets you spin up CTF events in your Microsoft Azure environment.
+- [GCP Goat](https://gcpgoat.joshuajebaraj.com/index.html) - An intentionally vulnerable GCP environment to learn and practice GCP security.
 - [FLAWS](http://flaws.cloud/) - A CTF site based on common mistakes and gotchas when using Amazon Web Services (AWS).
 - [FLAWS2](http://flaws2.cloud/) - The sequel to the flAWS.cloud CTF site with both an Attacker and Defender track using Amazon Web Services (AWS).
 - [Thunder CTF](https://thunder-ctf.cloud/) - A CTF site based on attacking vulnerable cloud projects on Google Cloud Platform (GCP).


### PR DESCRIPTION
[GCP Goat](https://gcpgoat.joshuajebaraj.com/index.html) - An intentionally vulnerable GCP environment to learn and practice GCP security.